### PR TITLE
Simplify mkContext

### DIFF
--- a/src/Trurl.hs
+++ b/src/Trurl.hs
@@ -98,10 +98,10 @@ aesonContext obj k  = let Object o = obj
                       in mkVariable v
 
 mkContext :: Monad m => String -> String -> MuType m
-mkContext paramsStr =
+mkContext paramsStr key =
   case decode $ BLC8.pack paramsStr of
-    Nothing  -> \_ -> MuVariable ("" :: String)
-    Just obj -> aesonContext obj
+    Nothing  -> MuVariable ("" :: String)
+    Just obj -> aesonContext obj key
 
 mkProjContext :: Monad m => String -> String -> String -> MuType m
 mkProjContext projName _ "ProjectName" = MuVariable projName


### PR DESCRIPTION
I find it hard to wrap my head around currying and lambdas and stuff, so let's get rid of some. Now it is more clear what is going on in `mkContext`, I think. The behaviour of the function hasn't changed at all.
